### PR TITLE
[Chore][EUX-223] Bump to 6.1.1

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,5 +6,5 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 6.1.0'
+  pod 'KustomerChat', '~> 6.1.1'
 end

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -396,7 +396,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.1.0;
+				minimumVersion = 6.1.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "2b8f5a19aef03d6476bcf2457a016a03addb6f06",
-        "version" : "6.1.0"
+        "revision" : "8e20360529949c1859f98fcbf0426d3fb75baf0a",
+        "version" : "6.1.1"
       }
     }
   ],


### PR DESCRIPTION
Bumping to 6.1.1
[EUX-223]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates KustomerChat (CocoaPods) and kustomer-ios-spm (SwiftPM) from 6.1.0 to 6.1.1.
> 
> - **Dependencies**:
>   - **CocoaPods**: Update `KustomerChat` in `chat-v2-sample/CocoaPods/Podfile` from `~> 6.1.0` to `~> 6.1.1`.
>   - **Swift Package Manager**:
>     - Bump `kustomer-ios-spm` minimum version to `6.1.1` in `project.pbxproj`.
>     - Update `Package.resolved` to version `6.1.1` with new revision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b605108c7c84eb7cb5cd1cf3163745b46ebeab2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->