### PR TITLE
[EUX-834] Bump to iOS SDK v6.2.1

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 6.2.0'
+  pod 'KustomerChat', '~> 6.2.1'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/README.md
+++ b/chat-v2-sample/README.md
@@ -1,4 +1,4 @@
-# swift-chat-v2-sample
+# iOS Sample App
 
 This sample app demonstrates the login and describe functionality available for [Kustomer Chat 2.0](https://help.kustomer.com/introduction-kustomer-chat-H1xk1Gb8v) in the [Kustomer iOS Chat SDK](https://developer.kustomer.com/chat-sdk/v2-iOS/docs).
 

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.2.0;
+				minimumVersion = 6.2.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "5116c7daf42972a28c1e7c84a25d4e50e99599b8",
-        "version" : "6.2.0"
+        "revision" : "a42667c028ca8c281680a80b7c3d8c24858dbf71",
+        "version" : "6.2.1"
       }
     }
   ],


### PR DESCRIPTION
# User description
Bump to iOS SDK v6.2.1

[EUX-834]

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the <code>KustomerChat</code> iOS SDK to version <code>6.2.1</code> for the sample application, configuring both CocoaPods and Swift Package Manager dependencies, and rename the sample application title in the <code>README.md</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymondjoneskustomer</td><td>EUX-774-Bump-to-6.2.0-51</td><td>November 14, 2025</td></tr>
<tr><td>raymond.jones@kustomer...</td><td>bump</td><td>April 07, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/kustomer/ios-chat-sdk-samples/52?tool=ast>(Baz)</a>.