### PR TITLE
[EUX-918] Bump Sample App to v6.3.0

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 6.2.1'
+  pod 'KustomerChat', '~> 6.3.0'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.2.1;
+				minimumVersion = 6.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "a42667c028ca8c281680a80b7c3d8c24858dbf71",
-        "version" : "6.2.1"
+        "revision" : "fb1b88c61bbfe79229ff8a4fd1dc70dcd2f4dce4",
+        "version" : "6.3.0"
       }
     }
   ],

--- a/chat-v2-sample/Shared/AppDelegate.swift
+++ b/chat-v2-sample/Shared/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Configure Kustomer with your API Key
     // Make sure to do this in your app delegate!
     let options = KustomerOptions()
-    options.logLevels = [.debug, .error]
+    options.logLevels = KustomerLogTypeAll
     options.pushEnvironment = .development
     _ = Kustomer.setup(apiKey: Constants.apiKey, options: options, launchOptions: launchOptions) { result in
       switch result {


### PR DESCRIPTION
# User description
Bumping sample app to 6.3.0

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the iOS sample application to integrate the newly released <code>KustomerChat</code> SDK version <code>6.3.0</code>, ensuring the app utilizes the latest features and improvements. Adjust the sample app's logging configuration to <code>KustomerLogTypeAll</code> for comprehensive debugging with the updated SDK.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymondjoneskustomer</td><td>EUX-834-Bump-to-iOS-SD...</td><td>November 26, 2025</td></tr>
<tr><td>raymond.jones@kustomer...</td><td>bump</td><td>April 07, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/kustomer/ios-chat-sdk-samples/53?tool=ast>(Baz)</a>.