### PR TITLE
[EUX-1187] Bump Sample app to 7.1.0 of iOS SDK

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.0.0'
+  pod 'KustomerChat', '~> 7.1.0'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				minimumVersion = 7.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "fc7978e09f0325e2d7d55add549212bdae289560",
-        "version" : "7.0.0"
+        "revision" : "015ed6a8e7479a6176a7ca5d1d3aee1eaddb5c2a",
+        "version" : "7.1.0"
       }
     }
   ],


### PR DESCRIPTION
# User description
[EUX-1187] Bump Sample app to 7.1.0 of iOS SDK

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Kustomer iOS SDK to version 7.1.0 within the sample application to align with the latest release. Modifies dependency configurations for both CocoaPods and Swift Package Manager to ensure the sample app utilizes the most recent SDK features and fixes.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymondjoneskustomer</td><td>bump-to-7.0.0-54</td><td>January 12, 2026</td></tr>
<tr><td>raymond.jones@kustomer...</td><td>bump</td><td>April 07, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/kustomer/ios-chat-sdk-samples/55?tool=ast>(Baz)</a>.