### PR TITLE
[EUX-1383] Bump to v7.1.1 of iOS

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.1.0'
+  pod 'KustomerChat', '~> 7.1.1'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.1.0;
+				minimumVersion = 7.1.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "015ed6a8e7479a6176a7ca5d1d3aee1eaddb5c2a",
-        "version" : "7.1.0"
+        "revision" : "d4fe9938bf0bc1a63f25f2fc98198dcb23ace26e",
+        "version" : "7.1.1"
       }
     }
   ],


### PR DESCRIPTION
# User description
Following release of v7.1.1, Bumping Sample app to use that version

[EUX-1383]

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>KustomerChat</code> SDK dependency to version 7.1.1 across the sample application's configuration files. Ensures the project utilizes the latest iOS SDK release by modifying CocoaPods and Swift Package Manager settings.

<details><summary>Checks (1)</summary><ul><li>Validate Podfile / Validate Podfile</li></ul></details>
<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/kustomer/ios-chat-sdk-samples/56?tool=ast>(Baz)</a>.