### PR TITLE
[EUX-1441] Bump to iOS SDK 7.1.2

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.1.1'
+  pod 'KustomerChat', '~> 7.1.2'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.1.1;
+				minimumVersion = 7.1.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "d4fe9938bf0bc1a63f25f2fc98198dcb23ace26e",
-        "version" : "7.1.1"
+        "revision" : "29bd2d2ed971af48e094cbc654e91c2b69439195",
+        "version" : "7.1.2"
       }
     }
   ],


### PR DESCRIPTION
# User description
Bumping iOS SDK to latest (7.1.2)

[EUX-1441]

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Kustomer iOS SDK to version 7.1.2 across the sample application's dependency configurations. Ensures that both CocoaPods and Swift Package Manager implementations reference the latest SDK release to maintain compatibility and include recent fixes.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymondjoneskustomer</td><td>bump-56</td><td>February 18, 2026</td></tr>
<tr><td>raymond.jones@kustomer...</td><td>bump</td><td>April 07, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/kustomer/ios-chat-sdk-samples/57?tool=ast>(Baz)</a>.