### PR TITLE
[Chore] Bumping native packages

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.1.2'
+  pod 'KustomerChat', '~> 7.1.5'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.1.2;
+				minimumVersion = 7.1.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "29bd2d2ed971af48e094cbc654e91c2b69439195",
-        "version" : "7.1.2"
+        "revision" : "1b77670d098aad855c07657eb23091d08e6b7df2",
+        "version" : "7.1.5"
       }
     }
   ],


### PR DESCRIPTION
# User description
Bumping Sample app to latest version of iOS SDK (`SPM` and `CocoaPods`)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the CocoaPods and SwiftPM configurations to reference the latest <code>KustomerChat</code> release so the sample app continues using the newest iOS SDK. Align the project’s package resolution and workspace settings with <code>7.1.5</code> so both dependency managers resolve the same version.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymondjoneskustomer</td><td>bump to 7.1.2 (#57)</td><td>March 30, 2026</td></tr>
<tr><td>raymond.jones@kustomer...</td><td>bump</td><td>April 07, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/kustomer/ios-chat-sdk-samples/59?tool=ast>(Baz)</a>.