### PR TITLE
[Chore] Bump chat v2 sample to KustomerChat 7.2.2 (CocoaPods + SPM)

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.1.5'
+  pod 'KustomerChat', '~> 7.2.2'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.1.5;
+				minimumVersion = 7.2.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "1b77670d098aad855c07657eb23091d08e6b7df2",
-        "version" : "7.1.5"
+        "revision" : "fdba7a66e7bf812a8ed048181d80042d9654bde8",
+        "version" : "7.2.2"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Upgrade the **chat v2** sample so both **CocoaPods** and **Swift Package Manager** integrations resolve **KustomerChat `7.2.2`** (from `7.1.5`), matching the current published **kustomer-ios-spm** release.

## Problem

The sample apps still pinned **`~> 7.1.5`** / **`minimumVersion = 7.1.5`**, so integrators following the repo do not pick up **`7.2.2`** by default.

## Reason

Keep **ios-chat-sdk-samples** aligned with the latest **KustomerChat** release for accurate smoke testing and copy-paste integration references.

## Solution

- **CocoaPods** — [`chat-v2-sample/CocoaPods/Podfile`](chat-v2-sample/CocoaPods/Podfile): `pod 'KustomerChat', '~> 7.2.2'`
- **SPM** — [`chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj`](chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj): `minimumVersion = 7.2.2`
- **Resolved revision** — [`Package.resolved`](chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved): revision + version updated for **`7.2.2`**

## Test plan

- [x] CocoaPods sample: `cd chat-v2-sample/CocoaPods && pod install` (or `pod update`), open workspace, **Build** target **swift-chat-v2-sample**
- [x] SPM sample: open **Remote-SPM** `.xcodeproj`, **File → Packages → Reset Package Caches** if needed, **Build** target **swift-chat-v2-sample**
- [x] Smoke: launch sample, open chat, send/receive a message