### PR TITLE
[Chore] bumping to 7.2.5

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.2.2'
+  pod 'KustomerChat', '~> 7.2.4'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.2.4'
+  pod 'KustomerChat', '~> 7.2.5'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.2.2;
+				minimumVersion = 7.2.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.2.4;
+				minimumVersion = 7.2.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "fdba7a66e7bf812a8ed048181d80042d9654bde8",
-        "version" : "7.2.2"
+        "revision" : "5b1e60eab0294691707be4a939f81634dba02b1a",
+        "version" : "7.2.4"
       }
     }
   ],

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "5b1e60eab0294691707be4a939f81634dba02b1a",
-        "version" : "7.2.4"
+        "revision" : "643539835a766b31e5c0bf6ca17c4078a9ac7883",
+        "version" : "7.2.5"
       }
     }
   ],


### PR DESCRIPTION
# User description
## Summary
- Bump Kustomer iOS SDK from 7.2.2 to 7.2.5 across chat-v2-sample integration paths
- Update CocoaPods `Podfile` constraint to `~> 7.2.5`
- Update Remote-SPM `project.pbxproj` minimum version and regenerate `Package.resolved` to pin `kustomer-ios-spm` 7.2.5

## Test plan
- [ ] Open `chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj` and confirm SPM resolves `kustomer-ios-spm` at 7.2.5
- [ ] Run `pod install` in `chat-v2-sample/CocoaPods` and confirm `KustomerChat` resolves to 7.2.5
- [ ] Build and run the sample app against a test org

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Raise the Kustomer SDK pin across CocoaPods and SPM integrations so the chat-v2 sample uses 7.2.5 consistently. Update CocoaPods <code>Podfile</code> constraint for <code>KustomerChat</code> and refresh the Remote-SPM workspace so it resolves <code>kustomer-ios-spm</code> 7.2.5.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/kustomer/ios-chat-sdk-samples/61?tool=ast&topic=CocoaPods+upgrade>CocoaPods upgrade</a>
        </td><td>Update CocoaPods constraint for <code>KustomerChat</code> to <code>~&gt; 7.2.5</code> so integrations build against the newer SDK.<details><summary>Modified files (1)</summary><ul><li>chat-v2-sample/CocoaPods/Podfile</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymond.jones@kustomer...</td><td>bump versions to 7.2.5</td><td>July 07, 2026</td></tr>
<tr><td>raymondjoneskustomer</td><td>bumping to 7.2.2 (#60)</td><td>June 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/kustomer/ios-chat-sdk-samples/61?tool=ast&topic=SPM+resolution>SPM resolution</a>
        </td><td>Refresh Remote-SPM references to lock <code>kustomer-ios-spm</code> at 7.2.5 in the project metadata and resolved state.<details><summary>Modified files (2)</summary><ul><li>chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj</li>
<li>chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymond.jones@kustomer...</td><td>bump versions to 7.2.5</td><td>July 07, 2026</td></tr>
<tr><td>raymondjoneskustomer</td><td>bumping to 7.2.2 (#60)</td><td>June 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/kustomer/ios-chat-sdk-samples/61?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>