### PR TITLE
[Chore] Bump Kustomer Chat SDK to 7.2.6

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.2.5'
+  pod 'KustomerChat', '~> 7.2.6'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.2.5;
+				minimumVersion = 7.2.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "643539835a766b31e5c0bf6ca17c4078a9ac7883",
-        "version" : "7.2.5"
+        "revision" : "ee89a79585fc970116c7c860611b7ab667cd5542",
+        "version" : "7.2.6"
       }
     }
   ],


### PR DESCRIPTION
# User description
## Summary
- Bumps the internal Kustomer Chat SDK version used by the sample app from 7.2.5 to 7.2.6.
- Updates both CocoaPods and Swift Package Manager sample configuration so they resolve the same SDK release.

## Test plan
- Not run; this PR only updates dependency version metadata and the resolved SPM revision.


Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the sample apps CocoaPods and SwiftPM configurations so their <code>KustomerChat</code> dependency now resolves version 7.2.6. Sync the SwiftPM workspace metadata to the matching revision for consistent builds.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymond.jones@kustomer...</td><td>[Chore] bump Kustomer ...</td><td>July 10, 2026</td></tr>
<tr><td>raymondjoneskustomer</td><td>[Chore] bumping to 7.2...</td><td>July 07, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/kustomer/ios-chat-sdk-samples/62?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>