### PR TITLE
Bump to iOS SDK 7.2.7

### DIFF
--- a/chat-v2-sample/CocoaPods/Podfile
+++ b/chat-v2-sample/CocoaPods/Podfile
@@ -6,7 +6,7 @@ target 'swift-chat-v2-sample' do
   use_frameworks!
 
   # Pods for swift-chat-v2-sample
-  pod 'KustomerChat', '~> 7.2.6'
+  pod 'KustomerChat', '~> 7.2.7'
 end
 
 post_install do |installer|

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			repositoryURL = "https://github.com/kustomer/kustomer-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.2.6;
+				minimumVersion = 7.2.7;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/chat-v2-sample/Remote-SPM/swift-chat-v2-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kustomer/kustomer-ios-spm",
       "state" : {
-        "revision" : "ee89a79585fc970116c7c860611b7ab667cd5542",
-        "version" : "7.2.6"
+        "revision" : "8e8b09bb621914311da8493c880720e93f5936fc",
+        "version" : "7.2.7"
       }
     }
   ],


### PR DESCRIPTION
# User description
Just bumping internal pin for iOS SDK to 7.2.7 (latest)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the sample app&#x27;s <code>KustomerChat</code> CocoaPods dependency and <code>kustomer-ios-spm</code> Swift package pin to iOS SDK 7.2.7. Refresh the Xcode project and resolved package state so the app builds against the latest internal SDK release.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymond.jones@kustomer...</td><td>bumped to 7.2.7</td><td>July 28, 2026</td></tr>
<tr><td>raymondjoneskustomer</td><td>[Chore] bump Kustomer ...</td><td>July 10, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/kustomer/ios-chat-sdk-samples/63?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>